### PR TITLE
Configure heroku migration & seed

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: node ace migration:run
+release: node ace migration:run --force
 web: node server.js

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
-web: ENV_SILENT=true node server.js
+release: node ace migration:run
+web: node server.js

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: ENV_SILENT=true node ace migration:run
+release: ENV_SILENT=true node ace migration:run --force
 web: ENV_SILENT=true node server.js

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: node ace migration:run --force
-web: node server.js
+release: ENV_SILENT=true node ace migration:run
+web: ENV_SILENT=true node server.js


### PR DESCRIPTION
We figured out how to add migrations to the Procfile.

In the release, do 
```
node ace migration:run --force
```
(Ace is part of adonis, I think this command is the same as `adonis migration:run`, except that the heroku app doesn't recognize the command adonis. Presumably this is because we globally installed adonis to get the command.) 

Adonis requires us to add the force flag when using a production app (possibly if we remove the node env production environment variable this would change).

As for the seeding, Felix informed us that it is not good practice to put the seeding in the Procfile as it is an administrative task which should be performed only once. (But it did work to add "&& node ace seed --force" to the release.)

Instead, use Heroku cli to seed. I ran the following from terminal:

```
heroku run bash --app proud-stories
```
to open up a shell in the production app and then `node ace seed --force` to do the seed. This can also be done from heroku dashboard by clicking "More" in the top right and opening a console.

Finally I repeated this all for proud-stories-staging.
