### PR TITLE
Change likes endpoint to allow users to use their balance

### DIFF
--- a/start/routes/index.js
+++ b/start/routes/index.js
@@ -233,33 +233,55 @@ Route.post("videos/:id/likes", async ({ request, response, params }) => {
     userId
   );
   //check one per day
-  if (likes.rows.length > 0) {
-    response.status(500).json({
-      status: 500,
-      error: "You reached your daily like limit"
-    });
-    return;
-  }
-  await Database.table("video_likes")
+  
+  //calculate the balance
+
+  //check if they haven't used a like today, use their free lik
+  if (likes.rows.length === 0) {
+    await Database.table("video_likes")
     .insert({
       video_id: videoId,
       user_id: userId,
       created_at: Database.fn.now(),
       updated_at: Database.fn.now()
-    })
-    .then( async () => {
-      //the like was created, now add a transaction
-      const transaction = await Transaction.create({sender_id: userId, receiver_id: video.user_id, amount: 10, type: 'like'})
-      response.status(200).json({ amount: transaction.amount, type: transaction.type });
-
-      //todo: use a ".then()" to check if transaction successfully inserted.
-    })
-    .catch((error) => {
-      response.status(500).json({
-        status: 500,
-        error
-      });
+    })  
+  } else {
+    //otherwise calculate the balance
+    let balance = 0
+    const transactions = await Database.table("transactions")
+      .where("receiver_id", userId)
+      .orWhere("sender_id", userId);
+    transactions.forEach((item) => {
+      if (item.type === "like" && item.sender_id === userId) {
+        balance -= item.amount;
+      } else if (item.type === "deposit" || item.receiver_id === userId) {
+        balance += item.amount;
+      }
     });
+    //if the balance is sufficient, create a like and deduct from balance
+    if (balance < 10) {
+      await Database.table("video_likes")
+        .insert({
+          video_id: videoId,
+          user_id: userId,
+          created_at: Database.fn.now(),
+          updated_at: Database.fn.now()
+        })
+        .then( async () => {
+          //the like was created, now add a transaction
+          const transaction = await Transaction.create({sender_id: userId, receiver_id: video.user_id, amount: 10, type: 'like'})
+          response.status(200).json({ amount: transaction.amount, type: transaction.type });
+
+          //todo: use a ".then()" to check if transaction successfully inserted.
+        })
+        .catch((error) => {
+          response.status(500).json({
+            status: 500,
+            error
+          });
+        });
+    }
+  }
 });
 //GET all transactions
 Route.get("transactions", async ({ params }) => {

--- a/start/routes/index.js
+++ b/start/routes/index.js
@@ -245,6 +245,7 @@ Route.post("videos/:id/likes", async ({ request, response, params }) => {
       created_at: Database.fn.now(),
       updated_at: Database.fn.now()
     })  
+    response.status(200)
   } else {
     //otherwise calculate the balance
     let balance = 0

--- a/start/routes/index.js
+++ b/start/routes/index.js
@@ -245,7 +245,7 @@ Route.post("videos/:id/likes", async ({ request, response, params }) => {
       created_at: Database.fn.now(),
       updated_at: Database.fn.now()
     })  
-    response.status(200)
+    response.status(200).send()
   } else {
     //otherwise calculate the balance
     let balance = 0

--- a/start/routes/index.js
+++ b/start/routes/index.js
@@ -259,7 +259,7 @@ Route.post("videos/:id/likes", async ({ request, response, params }) => {
       }
     });
     //if the balance is sufficient, create a like and deduct from balance
-    if (balance < 10) {
+    if (balance >= 10) {
       await Database.table("video_likes")
         .insert({
           video_id: videoId,
@@ -280,6 +280,9 @@ Route.post("videos/:id/likes", async ({ request, response, params }) => {
             error
           });
         });
+    }
+    else {
+      response.status(500).send({error: "Add credits."})
     }
   }
 });


### PR DESCRIPTION
I think this allows users to spend their balance.

First, if they haven't liked anything today they just use up their daily like, no transaction is posted.

If they have already liked something, then it checks if their balance is at least 10 yen, and if so posts a like and a transaction.